### PR TITLE
Use patch for sidecar updates

### DIFF
--- a/src/internal/controller.go
+++ b/src/internal/controller.go
@@ -70,11 +70,12 @@ func (r *RateLimitsReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	orig := rateLimits.DeepCopy()
 	if rateLimits.Annotations == nil {
 		rateLimits.Annotations = map[string]string{}
 	}
 	rateLimits.Annotations[selectorAnnotation] = currentSelectorStr
-	if err := r.Update(ctx, &rateLimits); err != nil {
+	if err := r.Patch(ctx, &rateLimits, client.MergeFrom(orig)); err != nil {
 		if errors.IsConflict(err) {
 			logger.Info("Skipping annotation update due to conflict", "ratelimits", rateLimits.Name)
 		} else {

--- a/src/internal/pod.go
+++ b/src/internal/pod.go
@@ -52,9 +52,10 @@ func (r *RateLimitsReconciler) reconcilePod(ctx context.Context, logger logr.Log
 	}
 
 	if r.needsSidecarUpdate(&deploy, rl) {
+		orig := deploy.DeepCopy()
 		injectSideCar(logger, &deploy, *rl)
 		r.updateDeploymentHash(&deploy, rl)
-		if err := r.Update(ctx, &deploy); err != nil {
+		if err := r.Patch(ctx, &deploy, client.MergeFrom(orig)); err != nil {
 			if errors.IsConflict(err) {
 				logger.Info("Skipping update due to conflict", "deployment", deploy.Name)
 			} else {

--- a/src/internal/sidecar.go
+++ b/src/internal/sidecar.go
@@ -151,9 +151,10 @@ func (r *RateLimitsReconciler) removeSidecarIfExists(ctx context.Context, deploy
 	logger := log.FromContext(ctx)
 
 	if hasSidecarInTemplate(&deploy) {
+		orig := deploy.DeepCopy()
 		removeSidecarContainer(&deploy)
 		delete(deploy.Spec.Template.Annotations, sidecarHash)
-		if err := r.Update(ctx, &deploy); err != nil {
+		if err := r.Patch(ctx, &deploy, client.MergeFrom(orig)); err != nil {
 			if errors.IsConflict(err) {
 				logger.Info("Skipping update due to conflict", "deployment", deploy.Name)
 			} else {


### PR DESCRIPTION
## Summary
- avoid overwriting other sidecar injections by using `client.Patch`

## Testing
- `make lint` *(fails: Forbidden - proxy.golang.org)*
- `make build` *(fails: Forbidden - proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_6873680f52a483239c54ae9f6adff2d7