### PR TITLE
Add StatefulSet support

### DIFF
--- a/src/internal/helpers.go
+++ b/src/internal/helpers.go
@@ -14,8 +14,21 @@ func findContainerIndex(deploy *appsv1.Deployment, name string) int {
 	return -1
 }
 
+func findContainerIndexStatefulSet(sts *appsv1.StatefulSet, name string) int {
+	for i, c := range sts.Spec.Template.Spec.Containers {
+		if c.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
 func hasSidecarInTemplate(deploy *appsv1.Deployment) bool {
 	return findContainerIndex(deploy, sidecarName) >= 0
+}
+
+func hasSidecarInStatefulSet(sts *appsv1.StatefulSet) bool {
+	return findContainerIndexStatefulSet(sts, sidecarName) >= 0
 }
 
 func removeSidecarContainer(deploy *appsv1.Deployment) {
@@ -26,6 +39,16 @@ func removeSidecarContainer(deploy *appsv1.Deployment) {
 		}
 	}
 	deploy.Spec.Template.Spec.Containers = updated
+}
+
+func removeSidecarContainerStatefulSet(sts *appsv1.StatefulSet) {
+	var updated []corev1.Container
+	for _, c := range sts.Spec.Template.Spec.Containers {
+		if c.Name != sidecarName {
+			updated = append(updated, c)
+		}
+	}
+	sts.Spec.Template.Spec.Containers = updated
 }
 
 func addConfigVolumes(tmpl *corev1.PodTemplateSpec) {

--- a/src/internal/setup.go
+++ b/src/internal/setup.go
@@ -11,6 +11,7 @@ import (
 func (r *RateLimitsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.RateLimits{}).
-		Watches(&appsv1.Deployment{}, handler.EnqueueRequestsFromMapFunc(r.mapDeploymentToCR)).
+		Watches(&appsv1.Deployment{}, handler.EnqueueRequestsFromMapFunc(r.mapWorkloadToCR)).
+		Watches(&appsv1.StatefulSet{}, handler.EnqueueRequestsFromMapFunc(r.mapWorkloadToCR)).
 		Complete(r)
 }

--- a/src/internal/sidecar.go
+++ b/src/internal/sidecar.go
@@ -34,6 +34,21 @@ func (r *RateLimitsReconciler) needsSidecarUpdate(deploy *appsv1.Deployment, rl 
 	return !hasSidecarInTemplate(deploy) || deploy.Spec.Template.Annotations[sidecarHash] != hash
 }
 
+func (r *RateLimitsReconciler) needsStatefulSetSidecarUpdate(sts *appsv1.StatefulSet, rl *v1.RateLimits) bool {
+	data := map[string]interface{}{
+		"ratelimits": rl.Spec.RateLimits,
+		"env":        rl.Spec.Env,
+	}
+	hashBytes, _ := json.Marshal(data)
+	hash := fmt.Sprintf("%x", sha256.Sum256(hashBytes))
+
+	if sts.Spec.Template.Annotations == nil {
+		sts.Spec.Template.Annotations = map[string]string{}
+	}
+
+	return !hasSidecarInStatefulSet(sts) || sts.Spec.Template.Annotations[sidecarHash] != hash
+}
+
 func (r *RateLimitsReconciler) updateDeploymentHash(deploy *appsv1.Deployment, rl *v1.RateLimits) {
 	data := map[string]interface{}{
 		"ratelimits": rl.Spec.RateLimits,
@@ -47,6 +62,21 @@ func (r *RateLimitsReconciler) updateDeploymentHash(deploy *appsv1.Deployment, r
 	}
 
 	deploy.Spec.Template.Annotations[sidecarHash] = hash
+}
+
+func (r *RateLimitsReconciler) updateStatefulSetHash(sts *appsv1.StatefulSet, rl *v1.RateLimits) {
+	data := map[string]interface{}{
+		"ratelimits": rl.Spec.RateLimits,
+		"env":        rl.Spec.Env,
+	}
+	hashBytes, _ := json.Marshal(data)
+	hash := fmt.Sprintf("%x", sha256.Sum256(hashBytes))
+
+	if sts.Spec.Template.Annotations == nil {
+		sts.Spec.Template.Annotations = map[string]string{}
+	}
+
+	sts.Spec.Template.Annotations[sidecarHash] = hash
 }
 
 func injectSideCar(logger logr.Logger, deploy *appsv1.Deployment, rl v1.RateLimits) {
@@ -112,6 +142,69 @@ func injectSideCar(logger logr.Logger, deploy *appsv1.Deployment, rl v1.RateLimi
 	addConfigVolumes(&deploy.Spec.Template)
 }
 
+func injectSideCarStatefulSet(logger logr.Logger, sts *appsv1.StatefulSet, rl v1.RateLimits) {
+	requiredEnv := []string{
+		"UPSTREAM_PORT", "UPSTREAM_HOST", "UPSTREAM_TYPE",
+		"CACHE_HOST", "CACHE_PORT", "CACHE_PROVIDER",
+		"CACHE_PREFIX", "REMOTE_IP_KEY",
+	}
+
+	envVars := map[string]string{
+		"CACHE_PREFIX": rl.Namespace,
+	}
+	for k, v := range rl.Spec.Env {
+		envVars[k] = v
+	}
+
+	var missing []string
+	for _, key := range requiredEnv {
+		if _, ok := envVars[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		logger.Error(nil, "Missing required environment variables for sidecar", "missing", missing)
+		return
+	}
+
+	var env []corev1.EnvVar
+	for k, v := range envVars {
+		env = append(env, corev1.EnvVar{Name: k, Value: v})
+	}
+
+	sidecar := corev1.Container{
+		Name:  sidecarName,
+		Image: sidecarImage,
+		Env:   env,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("200Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("200Mi"),
+			},
+		},
+		Ports: []corev1.ContainerPort{{
+			ContainerPort: sidecarPort,
+			Name:          sidecarName,
+			Protocol:      corev1.ProtocolTCP,
+		}},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: sidecarConfigMap, MountPath: sidecarMountPath, SubPath: sidecarSubPath},
+		},
+	}
+
+	if idx := findContainerIndexStatefulSet(sts, sidecarName); idx >= 0 {
+		sts.Spec.Template.Spec.Containers[idx] = sidecar
+	} else {
+		sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, sidecar)
+	}
+
+	addConfigVolumes(&sts.Spec.Template)
+}
+
 func (r *RateLimitsReconciler) removeSidecarFromOldMatches(ctx context.Context, ns string, oldSel, newSel labels.Selector) {
 	var pods corev1.PodList
 	if err := r.List(ctx, &pods, &client.ListOptions{Namespace: ns, LabelSelector: oldSel}); err != nil {
@@ -123,27 +216,37 @@ func (r *RateLimitsReconciler) removeSidecarFromOldMatches(ctx context.Context, 
 			continue
 		}
 
-		rsOwner := metav1.GetControllerOf(&pod)
-		if rsOwner == nil || rsOwner.Kind != "ReplicaSet" {
+		owner := metav1.GetControllerOf(&pod)
+		if owner == nil {
 			continue
 		}
 
-		var rs appsv1.ReplicaSet
-		if err := r.Get(ctx, types.NamespacedName{Name: rsOwner.Name, Namespace: pod.Namespace}, &rs); err != nil {
-			continue
-		}
+		switch owner.Kind {
+		case "ReplicaSet":
+			var rs appsv1.ReplicaSet
+			if err := r.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: pod.Namespace}, &rs); err != nil {
+				continue
+			}
 
-		deployOwner := metav1.GetControllerOf(&rs)
-		if deployOwner == nil || deployOwner.Kind != "Deployment" {
-			continue
-		}
+			deployOwner := metav1.GetControllerOf(&rs)
+			if deployOwner == nil || deployOwner.Kind != "Deployment" {
+				continue
+			}
 
-		var deploy appsv1.Deployment
-		if err := r.Get(ctx, types.NamespacedName{Name: deployOwner.Name, Namespace: pod.Namespace}, &deploy); err != nil {
-			continue
-		}
+			var deploy appsv1.Deployment
+			if err := r.Get(ctx, types.NamespacedName{Name: deployOwner.Name, Namespace: pod.Namespace}, &deploy); err != nil {
+				continue
+			}
 
-		r.removeSidecarIfExists(ctx, deploy)
+			r.removeSidecarIfExists(ctx, deploy)
+		case "StatefulSet":
+			var sts appsv1.StatefulSet
+			if err := r.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: pod.Namespace}, &sts); err != nil {
+				continue
+			}
+
+			r.removeSidecarStatefulSetIfExists(ctx, sts)
+		}
 	}
 }
 
@@ -159,6 +262,23 @@ func (r *RateLimitsReconciler) removeSidecarIfExists(ctx context.Context, deploy
 				logger.Info("Skipping update due to conflict", "deployment", deploy.Name)
 			} else {
 				logger.Error(err, "Failed to update Deployment with sidecar", "deployment", deploy.Name)
+			}
+		}
+	}
+}
+
+func (r *RateLimitsReconciler) removeSidecarStatefulSetIfExists(ctx context.Context, sts appsv1.StatefulSet) {
+	logger := log.FromContext(ctx)
+
+	if hasSidecarInStatefulSet(&sts) {
+		orig := sts.DeepCopy()
+		removeSidecarContainerStatefulSet(&sts)
+		delete(sts.Spec.Template.Annotations, sidecarHash)
+		if err := r.Patch(ctx, &sts, client.MergeFrom(orig)); err != nil {
+			if errors.IsConflict(err) {
+				logger.Info("Skipping update due to conflict", "statefulset", sts.Name)
+			} else {
+				logger.Error(err, "Failed to update StatefulSet with sidecar", "statefulset", sts.Name)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- watch StatefulSets for changes
- handle StatefulSet pods in reconciliation
- update helper utilities for StatefulSets
- inject/remove sidecar from StatefulSets

## Testing
- `make lint` *(fails: Forbidden)*
- `make build` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6873892358408323b6fd904000df4249